### PR TITLE
Enable passing the config argument to dingo_description

### DIFF
--- a/dingo_gazebo/launch/spawn_dingo.launch
+++ b/dingo_gazebo/launch/spawn_dingo.launch
@@ -14,7 +14,7 @@
 
   <!-- Load Dingo's description, controllers, and teleop nodes. -->
   <include file="$(find dingo_description)/launch/description.launch">
-    <!-- <arg name="config" value="$(arg config)" /> -->
+    <arg name="config" value="$(arg config)" />
   </include>
   <include file="$(find dingo_control)/launch/control.launch" />
   <include file="$(find dingo_control)/launch/teleop.launch">


### PR DESCRIPTION
Andrew caught this testing the tutorial docs.  When I tested it I must have accidentally run it in a terminal where I already had DINGO_CONFIG and/or DINGO_LASER defined.