### PR TITLE
Launch sim versions of extra sensor nodes

### DIFF
--- a/dingo_gazebo/launch/accessories/intel_realsense.launch
+++ b/dingo_gazebo/launch/accessories/intel_realsense.launch
@@ -1,0 +1,10 @@
+<launch>
+  <node pkg="depthimage_to_laserscan" type="depthimage_to_laserscan" name="$(optenv DINGO_REALSENSE_TOPIC realsense)_depth2laser">
+    <remap from="/image" to="$(optenv DINGO_REALSENSE_TOPIC realsense)/depth/image_rect_raw"/>
+    <remap from="/camera_info" to="$(optenv DINGO_REALSENSE_TOPIC realsense)/depth/camera_info"/>
+    <param name="range_min" value="0.5" />
+    <param name="range_max" value="5.46" />
+    <param name="output_frame_id" value="$(optenv DINGO_REALSENSE_MOUNT front)_realsense_link" />
+    <remap from="/scan" to="$(optenv DINGO_REALSENSE_TOPIC realsense)/scan" />
+  </node>
+</launch>

--- a/dingo_gazebo/launch/spawn_dingo.launch
+++ b/dingo_gazebo/launch/spawn_dingo.launch
@@ -31,4 +31,12 @@
   <!-- Spawn dingo -->
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model"
 	      args="-urdf -model dingo -param robot_description -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg yaw)" />
+
+  <!--
+    Launch any accessory nodes that would normally be part of dingo_bringup on a physical robot.
+    This doesn't include sensors that would be simulated, but can include additional services
+  -->
+  <group if="$(optenv DINGO_REALSENSE 0)">
+    <include file="$(dirname)/accessories/intel_realsense.launch" />
+  </group>
 </launch>

--- a/dingo_gazebo/package.xml
+++ b/dingo_gazebo/package.xml
@@ -10,6 +10,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend>depthimage_to_laserscan</exec_depend>
   <exec_depend>dingo_control</exec_depend>
   <exec_depend>dingo_description</exec_depend>
   <exec_depend>gazebo_plugins</exec_depend>


### PR DESCRIPTION
Add an accessories folder for launching additional nodes that would be part of the bringup on a real robot.  Currently populated with the corresponding realsense nodes from dingo_robot